### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "object-assign": "^3.0.0",
     "q": "^1.2.0",
     "through2": "^0.6.3",
-    "vinyl-fs": "^3.0.3",
-    "yargs": "^3.10.0"
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
     "jasmine": "^4.2.1",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that one of the runtime dependencies is installed, however, it is not used during the test runtime. We removed this dependency from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?
