### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "object-assign": "^3.0.0",
     "q": "^1.2.0",
     "through2": "^0.6.3",
-    "vinyl-fs": "^3.0.3",
-    "yargs": "^3.10.0"
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
     "jasmine": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "jasmine": "^4.2.1",
-    "jshint": "^2.13.4"
+    "jshint": "^2.13.4",
+    "yargs": "^3.10.0"
   }
 }


### PR DESCRIPTION
Hi,

Since the dependency `yargs` is not used in the unit tests, and is used in the `bin` folder. I would suggest installing this dependency as a dev dependency instead of a runtime dependency. 

What do you think?